### PR TITLE
refactor: Avoid converting type from Camel to Snake

### DIFF
--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -40,6 +40,7 @@ suite('Extension Test Suite', () => {
         assert.equal("dot", utils.dotCase("Dot"));
         assert.equal("dot", utils.dotCase("dot"));
         assert.equal("dot.case", utils.dotCase("DotCase"));
+        assert.equal("angle_uint32_t", utils.snakeCase("angleUint32_t"));
         assert.equal("hello.world", utils.dotCase("Hello World!"));
         assert.equal("dot.case.string", utils.dotCase("DotCaseString"));
 	});

--- a/src/utilities/stringUtility.ts
+++ b/src/utilities/stringUtility.ts
@@ -30,7 +30,11 @@ export class StringUtils extends Utility {
     }
 
     public snakeCase(input: string): string {
-        return _.snakeCase(input);
+        var pre_str = _.snakeCase(input);
+        
+        var s = pre_str.replace(/(.*)(int|INT)(\_)(8|16|32|64)(.*)/g, (_, begin, int_part, _underscore, bit_part, after) => 
+        `${begin}${int_part}${bit_part}${after}`);
+        return s;
     }
 
     public dotCase(input: string): string {


### PR DESCRIPTION
for the case like `fooBarInt32` it should not be converted into `foo_bar_int_32` but `foo_bar_int32`